### PR TITLE
Here's the updated commit message:

### DIFF
--- a/phase-1-action-items/actionitems.html
+++ b/phase-1-action-items/actionitems.html
@@ -47,6 +47,7 @@
         <header class="mb-8 text-center">
             <h1 class="text-3xl sm:text-4xl font-bold text-amber-700">Zoho CRM Build-Out Action Plan</h1>
             <p class="text-stone-600 mt-2">An interactive guide to your CRM implementation project.</p>
+            <p class="mt-2"><a href="../index.html" class="text-amber-600 hover:text-amber-700 underline">Back to Overview</a></p>
         </header>
 
         <nav class="mb-8">


### PR DESCRIPTION
Add 'Back to Overview' link in action items page

This commit adds a navigation link from the phase 1 action items page (`phase-1-action-items/actionitems.html`) back to the main `index.html` page.

The link is styled using Tailwind CSS and placed in the header for easy visibility.